### PR TITLE
Changed terminal package by a maintained one

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Choosing a development environment (e.g. editors, git GUIs, terminals, FTP clien
 Download and install these tools:
 * Editor: [Atom](https://atom.io/)
   * Atom packages/plug-ins:
-    * [Package Installation script here](https://gist.github.com/JTronLabs/941821b71a746dc31f418fd03a6c7236)
+    * [Package Installation script here](https://gist.github.com/talkahe/25d1f34d2aec3cf662b29309ec08635d)
     * atom-beautify ( `Ctrl/Cmd+comma` ➔ `Packages` ➔ Search for `atom-beautify` ➔ `Settings` ➔ toggle the `Beautify On Save` option for every language you want)
     * atom-html-preview (press `Ctrl+P` in the editor to open the preview)
     * fold-lines
-    * terminal-plus (terminal at bottom of editor)
+    * platformio-ide-terminal (terminal at bottom of editor)
     * markdown-preview (press `Ctrl+Shift+M` in the editor to open the preview)
     * linter (A linter is a small program that checks code for stylistic or programming errors. [Available linters](http://atomlinter.github.io/) )
     * linter-jshint (JavaScript linter)


### PR DESCRIPTION
The new package is [platformio-ide-terminal](https://atom.io/packages/platformio-ide-terminal). It supports newer Atom versions and Windows 10.
#23
